### PR TITLE
Trending 105

### DIFF
--- a/ui/bartendro/view/trending.py
+++ b/ui/bartendro/view/trending.py
@@ -41,8 +41,6 @@ def trending_drinks_date():
     if (len(begindate) > 0) :
         begin_ts = time.mktime(datetime.datetime.strptime(begindate, "%Y-%m-%d").timetuple())
         begin_ts = begin_ts + BARTENDRO_DAY_START_TIME 
-        #begindate = datetime.datetime.fromtimestamp(begin_ts).strftime('%Y-%m-%d %H:%M:%S')
-
         begindate = datetime.datetime.fromtimestamp(begin_ts).strftime('%c')
     else:
         begin_ts = 0 
@@ -56,11 +54,10 @@ def trending_drinks_date():
     else:
         end_ts = time.mktime(datetime.datetime.strptime(enddate, "%Y-%m-%d").timetuple())
         end_ts = end_ts + 24*60*60+BARTENDRO_DAY_START_TIME  - 1
-        #begin_ts = time.mktime(datetime.datetime.strptime(enddate, "%YYYY-m/-%d").timetuple())
         enddate = datetime.datetime.fromtimestamp(end_ts).strftime('%c')
 
     try:
-        txt = "Drinks poured from %s to %s <p>begin_ts: %i end_ts: %i" % (begindate, enddate,begin_ts, end_ts)
+        txt = "Drinks poured from %s to %s " % (begindate, enddate)
     except IndexError:
         txt = "Drinks poured by date"
 
@@ -130,7 +127,7 @@ def trending_drinks_detail(begindate, enddate, txt='', hours=''):
                  .params(begin=begindate, end=enddate).all()
 
     drinks_by_date = db.session.query("date",  "number", "volume")\
-                 .from_statement("""SELECT date(time-43200,'unixepoch') as date, 
+                 .from_statement("""SELECT date(time- :BARTENDRO_DAY_START_TIME,'unixepoch') as date, 
                                            count(drink_log.drink_id) AS number, 
                                            sum(drink_log.size) AS volume 
                                       FROM drink_log, drink_name, drink 
@@ -138,7 +135,7 @@ def trending_drinks_detail(begindate, enddate, txt='', hours=''):
                                        AND drink_name.id = drink.id
                                   GROUP BY date 
                                   ORDER BY date desc;""")\
-                 .params().all()
+                 .params(BARTENDRO_DAY_START_TIME=BARTENDRO_DAY_START_TIME).all()
 
     return render_template("trending", top_drinks = top_drinks, 
                                        drinks_by_date = drinks_by_date,

--- a/ui/bartendro/view/trending.py
+++ b/ui/bartendro/view/trending.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import time
+import time, datetime
 from bartendro import app, db
 from sqlalchemy import desc
 from flask import Flask, request, render_template
@@ -10,6 +10,7 @@ from bartendro.model.booze import Booze
 from bartendro.model.booze_group import BoozeGroup
 from bartendro.form.booze import BoozeForm
 
+BARTENDRO_DAY_START_TIME = 10 * 60 * 60
 DEFAULT_TIME = 12
 display_info = {
     12 : 'Drinks poured in the last 12 hours.',
@@ -20,7 +21,51 @@ display_info = {
 
 @app.route('/trending')
 def trending_drinks():
-    return trending_drinks_detail(DEFAULT_TIME)
+    return trending_drinks_detail(DEFAULT_TIME,'')
+
+# figure out begindate and enddate
+# begindate exists, but no enddate = assume it is one day
+# enddate exists but no beginndate = assume begindate=first day
+# need some text for this.
+# begin and enddate need to be in timestamp format.
+
+@app.route('/trending/date/')
+def trending_drinks_date():
+    """ this assumes ?begindate=yyyy-mm-dd&enddate=yyyy-mm-dd
+        or ?begindate=yyyy-mm-dd (with no enddate)
+    """
+
+    title = "Drinks by date"
+
+    begindate = request.args.get("begindate", "") 
+    if (len(begindate) > 0) :
+        begin_ts = time.mktime(datetime.datetime.strptime(begindate, "%Y-%m-%d").timetuple())
+        begin_ts = begin_ts + BARTENDRO_DAY_START_TIME 
+        #begindate = datetime.datetime.fromtimestamp(begin_ts).strftime('%Y-%m-%d %H:%M:%S')
+
+        begindate = datetime.datetime.fromtimestamp(begin_ts).strftime('%c')
+    else:
+        begin_ts = 0 
+        begindate = 'The beginning of time'
+
+    enddate = request.args.get("enddate", "") 
+    if (len(enddate) == 0):
+        end_ts = begin_ts + (24 * 60 * 60) - 1
+        #end_ts = end_ts + BARTENDRO_DAY_START_TIME - 1 
+        enddate = datetime.datetime.fromtimestamp(end_ts).strftime('%c')
+    else:
+        end_ts = time.mktime(datetime.datetime.strptime(enddate, "%Y-%m-%d").timetuple())
+        end_ts = end_ts + 24*60*60+BARTENDRO_DAY_START_TIME  - 1
+        #begin_ts = time.mktime(datetime.datetime.strptime(enddate, "%YYYY-m/-%d").timetuple())
+        enddate = datetime.datetime.fromtimestamp(end_ts).strftime('%c')
+
+    try:
+        txt = "Drinks poured from %s to %s <p>begin_ts: %i end_ts: %i" % (begindate, enddate,begin_ts, end_ts)
+    except IndexError:
+        txt = "Drinks poured by date"
+
+    hours = 0
+    return trending_drinks_detail(begin_ts, end_ts, txt, hours)
 
 @app.route('/trending/<int:hours>')
 def trending_drinks_detail(hours):
@@ -44,10 +89,19 @@ def trending_drinks_detail(hours):
         else:
             begindate = 0
     else:
-	begindate = 0
+        begindate = 0
         enddate = 0
         txt = ""
 
+    return trending_drinks_detail(begindate, enddate, txt, hours)
+
+
+def trending_drinks_detail(begindate, enddate, txt='', hours=''):
+
+    title = "Trending drinks"
+
+    #import pdb
+    #pdb.set_trace()
     total_number = db.session.query("number")\
                  .from_statement("""SELECT count(*) as number
                                       FROM drink_log 
@@ -75,9 +129,24 @@ def trending_drinks_detail(hours):
                                   ORDER BY count(drink_log.drink_id) desc;""")\
                  .params(begin=begindate, end=enddate).all()
 
-    return render_template("trending", top_drinks = top_drinks, options=app.options,
+    drinks_by_date = db.session.query("date",  "number", "volume")\
+                 .from_statement("""SELECT date(time-43200,'unixepoch') as date, 
+                                           count(drink_log.drink_id) AS number, 
+                                           sum(drink_log.size) AS volume 
+                                      FROM drink_log, drink_name, drink 
+                                     WHERE drink_log.drink_id = drink_name.id 
+                                       AND drink_name.id = drink.id
+                                  GROUP BY date 
+                                  ORDER BY date desc;""")\
+                 .params().all()
+
+    return render_template("trending", top_drinks = top_drinks, 
+                                       drinks_by_date = drinks_by_date,
+                                       options=app.options,
                                        title="Trending drinks",
                                        txt=txt,
                                        total_number=total_number[0],
                                        total_volume=total_volume[0],
                                        hours=hours)
+
+

--- a/ui/content/templates/trending
+++ b/ui/content/templates/trending
@@ -2,7 +2,8 @@
 {% set active = "trending" %}
 {% block body %}
 <div id="scroll-pane">
-    {% if top_drinks %}
+    <!-- { % if top_drinks %} -->
+    {% if 1%}
         <div class="row-fluid">
            <div class="span6">
                 <h1>{{ title }}</h1>
@@ -38,11 +39,27 @@
                {% endif %}
            </div>
         </div>
+
         <table class="table table-striped table-bordered">
            <tr><th>drink</th><th>number</th><th>volume</th></tr>
            {% for id, name, number, volume in top_drinks %}
                 <tr><td><a href="/drink/{{ id }}">{{ name }}</a></td><td>{{ number }}</td>
                 <td>
+                    {% if options.metric %}
+                        {{ "%.2f" | format((volume / 1000)|float) }} liters
+                    {% else %}
+                        {{ "%.2f" | format((volume / 1000) / 3.81|float) }} gallons
+                    {% endif %}
+           {% endfor %}
+        </table>
+        <h2>Drinks by Date</h2>
+        (A day starts at BARTENDRO_DAY_START_TIME, and lasts until BARTENDRO_DAY_START_TIME the next day)
+        <table class="table table-striped table-bordered">
+           <tr><th>date</th><th>number</th><th>volume</th></tr>
+           {% for date, number, volume in drinks_by_date %}
+                <tr><td><a href="/trending/date?begindate={{ date }}">{{ date }}</a></td><td>{{ number }}</td>
+                <td>
+
                     {% if options.metric %}
                         {{ "%.2f" | format((volume / 1000)|float) }} liters
                     {% else %}
@@ -56,6 +73,7 @@
          <a href="/" class="btn btn-large btn-warning button-border">Main menu</a>
        </div>
     {% endif %}
+
 </div>
 </script>
 {% endblock %}


### PR DESCRIPTION
This responds to issue #105 Trending Drinks improvement. This adds code to report drinks by date, with links to see the drinks served for a particular date.

This assumes that a Day, for Bartendro, starts at 10am, which is a hack to deal with events which run across midnight. 